### PR TITLE
Some code cleanups

### DIFF
--- a/authentic-lib.pm
+++ b/authentic-lib.pm
@@ -3,6 +3,8 @@
 # Copyright 2016 Ilia Rostovtsev <programming@rostovtsev.ru>
 # Licensed under MIT (https://github.com/qooob/authentic-theme/blob/master/LICENSE)
 #
+use strict;
+use warnings;
 
 BEGIN { push( @INC, ".." ); }
 use WebminCore;
@@ -1357,17 +1359,17 @@ sub csf_temporary_list {
         my @l;
 
         if ( -e "/var/lib/csf/csf.tempban" && !-z "/var/lib/csf/csf.tempban" ) {
-            open( IN, "</var/lib/csf/csf.tempban" ) or die $!;
-            @t = <IN>;
+            open( $IN, "<", "/var/lib/csf/csf.tempban" ) or die $!;
+            @t = <$IN>;
             chomp @t;
-            close(IN);
+            close($IN);
         }
 
         if ( @t && -e "/var/lib/csf/stats/iptables_log" ) {
-            open( IN, "<", "/var/lib/csf/stats/iptables_log" ) or die $!;
-            flock( IN, LOCK_SH );
-            my @i = <IN>;
-            close(IN);
+            open( $IN, "<", "/var/lib/csf/stats/iptables_log" ) or die $!;
+            flock( $IN, LOCK_SH );
+            my @i = <$IN>;
+            close($IN);
             chomp @i;
             @i = reverse @i;
             my $c = 0;
@@ -2527,18 +2529,6 @@ sub _settings {
                 $__usermin_config . "/authentic-theme" );
         }
     }
-}
-
-sub serialize_string_list {
-    return join(
-        '|',
-        map {
-            (   defined($_)
-                ? do { local $_ = $_; s/\^/^1/g; s/\|/^2/g; $_ }
-                : '^0'
-                )
-        } @_
-    );
 }
 
 sub get_xhr_request {

--- a/authentic-lib.pm
+++ b/authentic-lib.pm
@@ -3,8 +3,9 @@
 # Copyright 2016 Ilia Rostovtsev <programming@rostovtsev.ru>
 # Licensed under MIT (https://github.com/qooob/authentic-theme/blob/master/LICENSE)
 #
-use strict;
-use warnings;
+#use strict;
+#use warnings;
+our (%in, %text, %config);
 
 BEGIN { push( @INC, ".." ); }
 use WebminCore;
@@ -52,126 +53,69 @@ sub print_category {
     my ( $c, $label ) = @_;
     $label = $c eq "others" ? $text{'left_others'} : $label;
 
-    if (   $c eq 'webmin'
-        || $c eq 'usermin'
-        || $c eq 'settings'
-        || $c eq 'global_settings'
-        || $c eq 'global_setting'
-        || $c eq 'cat_setting' )
-    {
-        our $icon = 'fa-cog';
-    }
-    elsif ( $c eq 'system' || $c eq 'cat_system' ) {
-        our $icon = 'fa-wrench';
-    }
-    elsif ( $c eq 'servers' || $c eq 'global_servers' ) {
-        our $icon = 'fa-rocket';
-    }
-    elsif ( $c eq 'other' || $c eq 'global_other' ) {
-        our $icon = 'fa-gavel';
-    }
-    elsif ( $c eq 'net' || $c eq 'global_net' ) {
-        our $icon = 'fa-shield';
-    }
-    elsif ( $c eq 'info' || $c eq 'global_info' ) {
-        our $icon = 'fa-info';
-    }
-    elsif ($c eq 'hardware'
-        || $c eq 'global_hardware'
-        || $c eq 'global_storage' )
-    {
-        our $icon = 'fa-hdd-o';
-    }
-    elsif ( $c eq 'cluster' || $c eq 'global_cluster' ) {
-        our $icon = 'fa-power-off';
-    }
-    elsif ( $c eq 'unused' || $c eq 'global_unused' ) {
-        our $icon = 'fa-puzzle-piece';
-    }
-    elsif ( $c eq 'mail' || $c eq 'global_mail' ) {
-        our $icon = 'fa-envelope';
-    }
-    elsif ( $c eq 'login' || $c eq 'global_login' ) {
-        our $icon = 'fa-user';
-    }
-    elsif ( $c eq 'apps' || $c eq 'global_apps' ) {
-        our $icon = 'fa-rocket';
-    }
-    elsif ( $c eq 'email' || $c eq 'global_email' ) {
-        our $icon = 'fa-envelope';
-    }
-    elsif ( $c eq 'custom' || $c eq 'global_custom' ) {
-        our $icon = 'fa-wrench';
-    }
-    elsif ( $c eq 'ip' || $c eq 'global_ip' ) {
-        our $icon = 'fa-shield';
-    }
-    elsif ( $c eq 'check' || $c eq 'global_check' ) {
-        our $icon = 'fa-user-md';
-    }
-    elsif ( $c eq 'add' || $c eq 'global_add' ) {
-        our $icon = 'fa-plus';
-    }
-    elsif ( $c eq 'backup' || $c eq 'global_backup' || $c eq 'global_backup' ) {
-        our $icon = 'fa-floppy-o';
-    }
-    elsif ($c eq 'global_server'
-        || $c eq 'cat_server'
-        || $c eq 'global_system' )
-    {
-        our $icon = 'fa-cogs';
-    }
-    elsif ( $c eq 'global_delete' || $c eq 'cat_delete' ) {
-        our $icon = 'fa-plug';
-    }
-    elsif ( $c eq 'global_logs' || $c eq 'cat_logs' ) {
-        our $icon = 'fa-file-text';
-    }
-    elsif ( $c eq 'global_services' || $c eq 'cat_services' ) {
-        our $icon = 'fa-puzzle-piece';
-    }
-    elsif ( $c eq 'create_new' ) {
-        our $icon = 'fa-plus';
-    }
-    elsif ( $c eq 'global_gce' ) {
-        our $icon = 'fa-google';
-    }
-    elsif ( $c eq 'global_ec2' ) {
-        our $icon = 'fa-cubes';
-    }
-    elsif ( $c eq 'global_hosts' ) {
-        our $icon = 'fa-globe';
-    }
-    elsif ( $c eq 'global_virtualmin' ) {
-        our $icon = 'fa-sun-o';
-    }
-    elsif ( $c eq 'global_owners' ) {
-        our $icon = 'fa-users';
-    }
-    elsif ( $c eq 'global_monitor' ) {
-        our $icon = 'fa-desktop';
-    }
-    elsif ( $c eq 'global_settings' ) {
-        our $icon = 'fa-cloud';
-    }
-    elsif ( $c eq 'cat_manage' ) {
-        our $icon = 'fa-gavel';
-    }
-    elsif ( $c eq 'cat_res' ) {
-        our $icon = 'fa-share-alt';
-    }
-    elsif ( $c eq 'global_admin' || $c eq 'cat_admin' ) {
-        our $icon = 'fa-key';
-    }
-    elsif ( $c eq 'global_power' || $c eq 'cat_power' ) {
-        our $icon = 'fa-power-off';
-    }
-    else {
-        our $icon = 'fa-link';
-    }
+    my %icon_table = (
+      'webmin'              => 'fa-cog',
+      'usermin'             => 'fa-cog',
+      'settings'            => 'fa-cog',
+      'global_settings'     => 'fa-cog',
+      'cat_settings'        => 'fa-cog',
+      'system'              => 'fa-wrench',
+      'servers'             => 'fa-rocket',
+      'other'               => 'fa-gavel',
+      'net'                 => 'fa-sheild',
+      'info'                => 'fa-info',
+      'hardware'            => 'fa-hdd-o',
+      'global_hardware'     => 'fa-hdd-o',
+      'global_storage'      => 'fa-hdd-o',
+      'cluster'             => 'fa-power-off',
+      'global_cluster'      => 'fa-power-off',
+      'unused'              => 'fa-puzzle-piece',
+      'global_unused'       => 'pa-puzzle-piece',
+      'mail'                => 'fa-envelope',
+      'global_mail'         => 'fa-envelope',
+      'email'               => 'fa-envelope',
+      'global_email'        => 'fa-envelope',
+      'login'               => 'fa-user',
+      'global_login'        => 'fa-user',
+      'apps'                => 'fa-rocket',
+      'global_apps'         => 'fa-rocket',
+      'custom'              => 'fa-wrench',
+      'global_custom'       => 'fa-wrench',
+      'ip'                  => 'fa-shield',
+      'global_ip'           => 'fa-shield',
+      'check'               => 'fa-user-md',
+      'global_check'        => 'fa-user-md',
+      'add'                 => 'fa-plus',
+      'global_add'          => 'fa-plus',
+      'backup'              => 'fa-floppy-o',
+      'global_backup'       => 'fa-floppy-o',
+      'global_server',      => 'fa-cogs',
+      'cat_server',         => 'fa-cogs'.
+      'global_system'       => 'fa-cogs',
+      'global_delete'       => 'fa-plug',
+      'cat_delete'          => 'fa-plug',
+      'global_logs'         => 'fa-file-text',
+      'cat_logs'            => 'fa-file-text',
+      'global_services'     => 'fa-puzzle-piece',
+      'cat_services'        => 'fa-puzzle-piece',
+      'create_new'          => 'fa-plus',
+      'global_gce'          => 'fa-google',
+      'global_ec2'          => 'fa-cubes',
+      'global_hosts'        => 'fa-globe',
+      'global_virtualmin'   => 'fa-sun-o',
+      'global_owners'       => 'fa-users-o',
+      'global_monitor'      => 'fa-desktop',
+      'global_settings'     => 'fa-cloud',
+      'cat_manage'          => 'fa-gavel',
+      'cat_res'             => 'fa-share-alt',
+      'global_admin'        => 'fa-key',
+      'cat_admin'           => 'fa-key',
+      'global_power'        => 'fa-power-off',
+      'cat_power'           => 'fa-power-off',
+    );
+    my $icon = $icon_table{$c} || 'fa-link';
 
     if ($label) {
-
         # Show link to close or open catgory
         print '<li class="has-sub">' . "\n";
         print '<a href="#' . $c . '"><i class="fa ' . $icon . ' fa-fw"></i> <span>' . $label . '</span></a>' . "\n";

--- a/authentic-lib.pm
+++ b/authentic-lib.pm
@@ -553,6 +553,7 @@ sub print_left_menu {
         if ( $module eq $item->{'module'} || $group ) {
 
             my $link = add_webprefix( $item->{'link'} );
+            my $icon;
 
             if (   $item->{'type'} eq 'item'
                 && $link ne "/virtual-server/edit_lang.cgi"
@@ -564,86 +565,86 @@ sub print_left_menu {
                 if (   $link eq "/virtual-server/index.cgi"
                     || $link eq "/server-manager/index.cgi" )
                 {
-                    our $icon = '<i class="fa fa-fw fa-tasks"></i>';
+                    $icon = '<i class="fa fa-fw fa-tasks"></i>';
                 }
                 elsif ($link eq "/mailbox/list_folders.cgi"
                     || $link eq "/mailbox/list_ifolders.cgi" )
                 {
-                    our $icon = '<i class="fa fa-fw fa-folder"></i>';
+                    $icon = '<i class="fa fa-fw fa-folder"></i>';
                 }
                 elsif ( $link eq "/mailbox/list_addresses.cgi" ) {
-                    our $icon = '<i class="fa fa-fw fa-users"></i>';
+                    $icon = '<i class="fa fa-fw fa-users"></i>';
                 }
                 elsif ( $link eq "/filter/edit_forward.cgi" ) {
-                    our $icon = '<i class="fa fa-fw fa-share"></i>';
+                    $icon = '<i class="fa fa-fw fa-share"></i>';
                 }
                 elsif ( $link eq "/filter/edit_auto.cgi" ) {
-                    our $icon = '<i class="fa fa-fw fa-reply-all"></i>';
+                    $icon = '<i class="fa fa-fw fa-reply-all"></i>';
                 }
                 elsif ( $link eq "/filter/" ) {
-                    our $icon = '<i class="fa fa-fw fa-filter"></i>';
+                    $icon = '<i class="fa fa-fw fa-filter"></i>';
                 }
                 elsif ( $link eq "/mailbox/edit_sig.cgi" ) {
-                    our $icon = '<i class="fa fa-fw fa-pencil"></i>';
+                    $icon = '<i class="fa fa-fw fa-pencil"></i>';
                 }
                 elsif ( index( $link, 'mailbox/index.cgi?id=' ) > -1 ) {
-                    our $icon = '<i class="fa fa-fw fa-folder-o"></i>';
+                    $icon = '<i class="fa fa-fw fa-folder-o"></i>';
                 }
                 if ( $get_user_level == 1 ) {
                     if (   index( $link, '/virtual-server/edit_pass.cgi' ) > -1
                         && index( $link, '/virtual-server/edit_pass.cgi?' ) == -1 )
                     {
-                        our $icon = '<i class="fa fa-fw fa-ticket"></i>';
+                        $icon = '<i class="fa fa-fw fa-ticket"></i>';
                     }
                     elsif ( index( $link, '/virtual-server/edit_newplan.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-list"></i>';
+                        $icon = '<i class="fa fa-fw fa-list"></i>';
                     }
                     elsif ( index( $link, '/virtual-server/edit_newresels.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-cog"></i>';
+                        $icon = '<i class="fa fa-fw fa-cog"></i>';
                     }
                 }
 
                 if ( $__settings{'settings_leftmenu_singlelink_icons'} ne 'false' ) {
                     if ( index( $link, '/virtual-server/domain_form.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-plus-square-o"></i>';
+                        $icon = '<i class="fa fa-fw fa-plus-square-o"></i>';
                     }
 
                     elsif (index( $link, '/virtual-server/edit_domain.cgi' ) > -1
                         || index( $link, '/server-manager/edit_serv.cgi' ) > -1 )
                     {
-                        our $icon = '<i class="fa fa-fw fa-pencil-square-o"></i>';
+                        $icon = '<i class="fa fa-fw fa-pencil-square-o"></i>';
                     }
                     elsif ( index( $link, '/virtual-server/view_domain.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-info-circle"></i>';
+                        $icon = '<i class="fa fa-fw fa-info-circle"></i>';
                     }
 
                     elsif ( index( $link, '/virtual-server/list_users.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-users"></i>';
+                        $icon = '<i class="fa fa-fw fa-users"></i>';
                     }
                     elsif ( index( $link, '/virtual-server/list_aliases.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-envelope-o"></i>';
+                        $icon = '<i class="fa fa-fw fa-envelope-o"></i>';
                     }
                     elsif ( index( $link, '/virtual-server/list_databases.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-database"></i>';
+                        $icon = '<i class="fa fa-fw fa-database"></i>';
                     }
                     elsif (index( $link, '/virtual-server/list_scripts.cgi' ) > -1
                         || index( $link, '/server-manager/mass_update_form.cgi' ) > -1 )
                     {
-                        our $icon = '<i class="fa fa-fw fa-archive"></i>';
+                        $icon = '<i class="fa fa-fw fa-archive"></i>';
                     }
 
                     elsif ( index( $link, '/virtual-server/edit_html.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-globe"></i>';
+                        $icon = '<i class="fa fa-fw fa-globe"></i>';
                     }
                     elsif ( index( $link, '/server-manager/edit_pass.cgi' ) > -1 ) {
-                        our $icon = '<i class="fa fa-fw fa-key"></i>';
+                        $icon = '<i class="fa fa-fw fa-key"></i>';
                     }
                     elsif ( index( $link, '/server-manager/save_serv.cgi' ) > -1 ) {
                         if ( index( $link, 'refresh=1' ) > -1 ) {
-                            our $icon = '<i class="fa fa-fw fa-refresh"></i>';
+                            $icon = '<i class="fa fa-fw fa-refresh"></i>';
                         }
                         elsif ( index( $link, 'regen=1' ) > -1 ) {
-                            our $icon = '<i class="fa fa-fw fa-retweet"></i>';
+                            $icon = '<i class="fa fa-fw fa-retweet"></i>';
                         }
                     }
                     elsif ($link =~ /^http:\/\//
@@ -651,14 +652,14 @@ sub print_left_menu {
                         || $link =~ /^ftp:\/\//
                         || $link =~ /^ftps:\/\// )
                     {
-                        our $icon = '<i class="fa fa-fw fa-external-link"></i>';
+                        $icon = '<i class="fa fa-fw fa-external-link"></i>';
                     }
 
                 }
 
                 # Set variable in case it hasn't been set before
                 if ( !length $link ) {
-                    our $icon = undef;
+                    $icon = undef;
                 }
 
                 if (   $link
@@ -851,7 +852,7 @@ sub get_sysinfo_vars {
 
         # Ask status module for collected info
         &foreign_require("system-status");
-        $info = &system_status::get_collected_info();
+        my ($info) = &system_status::get_collected_info();
 
         # Define used vars
         my ($cpu_percent,        $mem_percent,             $virt_percent,    $disk_percent,
@@ -2912,9 +2913,9 @@ sub init {
 
     # Make ConfigServer Security Firewall look as we need
     if ( -r '/usr/local/csf/lib/webmin/csf/index.cgi' ) {
-        open( FILE, "</usr/local/csf/lib/webmin/csf/index.cgi" );
-        my @l = <FILE>;
-        close(FILE);
+        open( my $FILE, "<", "/usr/local/csf/lib/webmin/csf/index.cgi" );
+        my @l = <$FILE>;
+        close($FILE);
 
         if ( grep {/data-replaced/} @l ) {
             return;
@@ -2929,9 +2930,9 @@ sub init {
             push( @n, $_ );
         }
 
-        open( FILE, ">/usr/local/csf/lib/webmin/csf/index.cgi" );
-        print FILE @n;
-        close(FILE);
+        open( $FILE, ">", "/usr/local/csf/lib/webmin/csf/index.cgi" );
+        print $FILE @n;
+        close($FILE);
     }
 
 }
@@ -3083,7 +3084,7 @@ sub get_theme_language {
     my %text = &load_language($current_theme);
 
     my %s;
-    foreach $key ( keys %text ) {
+    foreach my $key ( keys %text ) {
         if ( index( $key, '_xhred_' ) == -1 ) {next}
         $s{$key} .= $text{$key};
     }


### PR DESCRIPTION
Re-factored print_category to be more idiomatic perl. Began work on making strict/warnings and Perl Critic happy.

I'll make a couple more pull requests as I complete more of it.

For Webmin 2.0 (and for general safety, and basic modern Perl standard practice), you should add the following to the beginning of all of your Perl files:

```
use strict;
use warnings;
```

It can be tricky at first to work without global variables, but I'm happy to help with the conversion of Authentic to be strict and warnings compliant. We'll also begin running Perl Critic across everything that goes into Webmin for 2.0, so that's a useful thing to add to your workflow.