### PR TITLE
Fix for buttons_row not working on Usermin config page

### DIFF
--- a/authentic.pm
+++ b/authentic.pm
@@ -1153,6 +1153,7 @@ sub theme_ui_buttons_row
     return
         "<form action='$script' class='ui_buttons_form'>\n"
       . $hiddens
+      . "<table>"
       . "<tr class='ui_buttons_row'> "
       . "<td nowrap width=20% valign=top class=ui_buttons_label>"
       . ( $before ? $before . " " : "" )
@@ -1162,6 +1163,7 @@ sub theme_ui_buttons_row
       . "<td width=80% valign=top class=ui_buttons_value>"
       . $desc
       . "</td></tr>\n"
+      . "</table>\n"
       . "</form>\n";
 }
 


### PR DESCRIPTION
Probably affects other pages, too.

I found it by running the HTML through the W3C validator and spotting badly nested tables and forms.