### PR TITLE
Fix system stats when the server have no virtual memory

### DIFF
--- a/stats.cgi
+++ b/stats.cgi
@@ -43,12 +43,14 @@ if ($in{'xhr-stats'} =~ /[[:alpha:]]/) {
                               text('body_used', nice_size(($memory[0]) * 1000), nice_size(($memory[0] - $memory[1]) * 1000))
                              ] :
                              []);
-            $data{'virt'} = (
+            if ($memory[2] > 0) {
+                $data{'virt'} = (
                            @memory && $memory[2] ?
                              [(100 - int(($memory[3] / $memory[2]) * 100)),
                               text('body_used', nice_size(($memory[2]) * 1000), nice_size(($memory[2] - $memory[3]) * 1000))
                              ] :
                              []);
+            }
             $data{'proc'} = scalar(@processes);
         }
 


### PR DESCRIPTION
@qooob: If the server have no virtual memory configured, the stats on the Webmin start page will stall as the request to stats.cgi will return error 500:

<h1>Error - Perl execution failed</h1>
<p>Illegal division by zero at /usr/share/webmin/authentic-theme/stats.cgi line 40.</p>

My fix checks first for the existence of virtual memory on the machine before calculating its stats, otherwise it will not be shown.